### PR TITLE
Fix Typo on Challenges Page

### DIFF
--- a/src/components/layouts/challenge-layout/index.tsx
+++ b/src/components/layouts/challenge-layout/index.tsx
@@ -199,7 +199,7 @@ const ChallengeLayout = (): JSX.Element => {
                       Diego?
                     </p>
                   )}
-                  {!equitable && <h2 className="card-text">Safe Roadways</h2>}
+                  {!equitable && <h2 className="card-text">Equitable Access</h2>}
                 </div>
               </Card>
             </Col>


### PR DESCRIPTION
Fix typo on `/challenges` page for "Safe Roadways" => "Equitable Access".