### PR TITLE
Fix css load ordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1130,12 +1130,51 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "@d4sd/components": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@d4sd/components/-/components-3.1.3.tgz",
-      "integrity": "sha512-fh07rx0YDkeAJWJ56Nm5OWrysQ+Sd8OtgNBIKteURSPoKpZ4S+W7JoW1rAyFfx+fyHSBHyj7Q8eapVoyee8x+g==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@d4sd/components/-/components-3.1.4.tgz",
+      "integrity": "sha512-5CJbZBD/bWIQ4WQsSp/EPclUJ+YUEpOpxpckrITf+wwok4obGcLaSbWfeqimE6oBpgI3Yeftu7u8Rtav1OSKCw==",
       "requires": {
         "antd": "^3.25.0",
+        "autoprefixer": "^9.7.4",
+        "mini-css-extract-plugin": "^0.9.0",
         "svg-loader": "0.0.2"
+      },
+      "dependencies": {
+        "autoprefixer": {
+          "version": "9.7.4",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.4.tgz",
+          "integrity": "sha512-g0Ya30YrMBAEZk60lp+qfX5YQllG+S5W3GYCFvyHTvhOki0AEQJLPEcIuGRsqVwLi8FvXPVtwTGhfr38hVpm0g==",
+          "requires": {
+            "browserslist": "^4.8.3",
+            "caniuse-lite": "^1.0.30001020",
+            "chalk": "^2.4.2",
+            "normalize-range": "^0.1.2",
+            "num2fraction": "^1.2.2",
+            "postcss": "^7.0.26",
+            "postcss-value-parser": "^4.0.2"
+          }
+        },
+        "mini-css-extract-plugin": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz",
+          "integrity": "sha512-lp3GeY7ygcgAmVIcRPBVhIkf8Us7FZjA+ILpal44qLdSu11wmjKQ3d9k15lfD7pO4esu9eUIAW7qiYIBppv40A==",
+          "requires": {
+            "loader-utils": "^1.1.0",
+            "normalize-url": "1.9.1",
+            "schema-utils": "^1.0.0",
+            "webpack-sources": "^1.1.0"
+          }
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
       }
     },
     "@emotion/is-prop-valid": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@d4sd/components": "^3.1.3",
+    "@d4sd/components": "^3.1.4",
     "@types/jest": "^24.0.20",
     "@types/node": "^12.11.7",
     "@types/react": "^16.9.11",

--- a/src/index.less
+++ b/src/index.less
@@ -1,3 +1,4 @@
+@import '~antd/dist/antd.css';
+@import '~@d4sd/components/lib/main.css';
 @import './styles/vars.less';
 @import './styles/fonts.less';
-@import '~antd/dist/antd.css';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import 'react-app-polyfill/ie11';
 import 'react-app-polyfill/stable';
-
+import './index.less';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { ConnectedRouter } from 'connected-react-router';
@@ -23,7 +23,7 @@ import FeedbackPage from './components/layouts/feedback-layout'
 import ViewFeedbackLayout from './components/layouts/view-feedback-layout';
 import CommunityFeedbackLayout from './components/layouts/community-feedback-layout';
 import PreliminarySubmissionPage from './components/layouts/preliminary-submission-layout';
-import './index.less';
+
 
 // eslint-disable-next-line
 // @ts-ignore


### PR DESCRIPTION
Updated d4sd components to reflect this, exports all CSS to separate file now (that should be imported in order to be used, like ant design)

Moved order in which all our component library css is imported